### PR TITLE
Verify package checksum before installing

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,8 @@
 # @see http://docs.ansible.com/playbooks_roles.html#roles
 #
 
-levant_version: 0.2.1
+levant_version:  0.2.1
+levant_checksum: sha256:65af9347c9b0fc443a1041beda602368fa36bb40f5d6f0d6721069401878b28c
 
 levant_archive:  "linux-amd64-levant"
 levant_download: "https://github.com/jrasell/levant/releases/download/{{ levant_version }}/{{ levant_archive }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,8 @@
 
 - name: Download levant
   get_url:
-    url: "{{ levant_download }}"
-    dest: "{{ levant_home }}/levant"
-    mode: "a+x"
+    url:      "{{ levant_download }}"
+    dest:     "{{ levant_home }}/levant"
+    mode:     "a+x"
+    checksum: "{{ levant_checksum }}"
   register: levant_was_downloaded


### PR DESCRIPTION
This role was created before the levant release process was configured to generate checksums of the packages. This PR adds verification of the checksum prior to installation, which is the accepted practice for downloads within ansible roles.